### PR TITLE
Permanent marker weight reduction

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -463,7 +463,7 @@
     "type": "TOOL",
     "name": { "str": "permanent marker" },
     "description": "A King Size™ industrial-strength permanent marker, about halfway between a typical marker and a can of spray paint in size.  Activate it to write something down.  However, writing \"Elbereth\" probably won't help you.",
-    "weight": "113 g",
+    "weight": "28 g",
     "volume": "50 ml",
     "price": 500,
     "price_postapoc": 10,


### PR DESCRIPTION
Permanent marker weight reduction

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Permanent marker weight reduction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Permanent marker as a game item weighs a quarter-pound (113 g). It shouldn't.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The game description divulges that these are based on the king-size Sharpie. 

Amazon has a 4-piece package of Sharpie King Size at 0.5 lb total, suggesting 0.125 lb (56.7 g/2 oz) per unit as a ceiling. The page also displays an "item weight" of 3.2 oz (90.7 g).

But this is an outlier. JetPens' detailed spec sheet assures us that the weight of one unit of the same marker, including ink and cap, is exactly 28g (~1 oz). The next supplier specifies an item weight of 0.297 lb for each 4-pack, for an individual unit weight of 33.68 g. They also list a carton of 96 (24x4) as weighing 7.59 lb, or 3442.77 g total, for a maximum of 35.86 g per unit. U-line lists their unit weight as 0.07 lb, or up to 32 grams.  Since we do have to account for packing weight, in all likelihood the exact 1 oz specification is correct.

If yet more corroboration is needed, other Amazon listings provide weight figures such as 4.16 oz for 4 markers, or even 1.37 lb for 24, which would come out to even less than 1 oz per marker. 

Perhaps some are instinctively discomfited by survivors rocking trenchcoats layered with markers, waiting to accost innocent merchants in dingy alleys. Nevertheless, I propose adjusting the weight of a permanent marker to 28 g (0.06 lb). The evidence convergently supports or permits this figure. Otherwise, reductio ad absurdum giant novelty marker.

![giant-marker-pool-float-0](https://github.com/Montimorency/Montimorency/assets/151707610/873e8311-adaf-4372-beb7-2e237c4938b6)

To compensate, I will for thorougness review the volume, which is currently 0.05 L, or just slightly barely bigger than a pen. According to the JetPens page, the grip diameter of the marker is 21 mm, while its capped length is 142 mm. By formula: 

V = πr^2h = π·10.5^2·142 = 49183.204

A good game approximation volume would thus be 0.049 cubic milliliters, which is — wait a second. Whoops... maybe our pens are just too chunky?

So the volume should remain as is.  That's all for a day's work! Maybe next I'll draft-mode the PR in order to swap "permanent marker" from the Misc tool json to the Stationery tool json, if people think that's a good idea. I don't see why the marker entry shouldn't sit alongside the pen and pencil entries.

https://www.amazon.com/Sharpie-15661PP-Permanent-Marker-4-Count/dp/B0013CQ20Q
https://www.jetpens.com/Sharpie-King-Size-Permanent-Marker-Chisel-Tip-Black/pd/15854#index=1
https://www.ontimesupplies.com/san1799262-king-size-permanent-marker-broad-chisel-tip-assorted-colors-4-set.html
https://www.uline.com/Product/Detail/H-255BL/Pallet-Markers/Sharpie-King-Size-Markers-Black
https://www.amazon.com/Sharpie-15661PP-Permanent-Markers-Black/dp/B00PV19OV4
https://www.amazon.com/Permanent-Markers-Chisel-Plastic-Leather/dp/B0CPDSQ264
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Markers now appear with the correct weight. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's another problem, which is that ink is sized such that a full permanent marker contains 0.5 L of ink, despite being 0.05L in volume as a whole. Even regular pens, when full, contain 0.1 L of ink within a 0.04 L frame. Pencils are the same with graphite, but as their ammo type is not a fluid - dischargeable - it doesn't get represented in the item description. This can't be solved by reducing the volume of permanent ink units, as they are 0.01 ml, which is the current hardcoded minimum. It's merely a trivial flaw in the math of the world, but I might as well highlight it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
